### PR TITLE
Fix churn chance else message

### DIFF
--- a/client.ipynb
+++ b/client.ipynb
@@ -80,7 +80,7 @@
     "if pred > 0.5:\n",
     "    print(f\"The {pred:.2%} chance that customer can churn\")\n",
     "else:\n",
-    "    print(\"The customer might not churn, the churn chance is low {pred}%\")"
+    "    print(f\"The customer might not churn, the churn chance is low {pred:.2%}\")\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- tweak message in **client.ipynb** when churn probability is low

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68401d32bc548331a300be5314d71d1d